### PR TITLE
MSP-3: Redirect / to project page on GitHub

### DIFF
--- a/mbspotify/views.py
+++ b/mbspotify/views.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from flask import Blueprint, request, Response, jsonify, current_app
+from flask import Blueprint, redirect, request, Response, jsonify, current_app
 from werkzeug.exceptions import BadRequest, ServiceUnavailable
 from mbspotify.decorators import key_required, jsonp
 from mbspotify.utils import validate_uuid
@@ -12,7 +12,8 @@ main_bp = Blueprint('ws_review', __name__)
 
 @main_bp.route("/")
 def index():
-    return "<html>Piss off!</html>"
+    """Redirect to project page on GitHub."""
+    return redirect("https://github.com/metabrainz/mbspotify", code=302)
 
 
 @main_bp.route("/mapping/add", methods=["POST"])

--- a/mbspotify/views_test.py
+++ b/mbspotify/views_test.py
@@ -55,9 +55,10 @@ class ViewsTestCase(TestCase):
         return app
 
     def test_index(self):
+        """Test that index page redirects to the project page on GitHub."""
         response = self.client.get("/")
-        # Index page should ask users to piss off.
-        self.assertIn("Piss off!", str(response.data))
+        self.assertStatus(response, 302)
+        self.assertRedirects(response, "https://github.com/metabrainz/mbspotify")
 
     def test_vote(self):
         # Adding a new mapping


### PR DESCRIPTION
Instead of creating a new HTML page as in https://github.com/metabrainz/mbspotify/pull/35 just makes / do a 302 redirect to GitHub page.